### PR TITLE
Reduced Motion Toggle + Link Highlight

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -114,4 +114,11 @@ select {
 
 }
 
-  
+/* Reduced motion component */
+.reduced-motion *, 
+.reduced-motion *::before, 
+.reduced-motion *::after {
+	animation: none !important;
+	transition: none !important;
+	scroll-behavior: auto !important;
+}

--- a/src/lib/components/AccessibilityMenu.svelte
+++ b/src/lib/components/AccessibilityMenu.svelte
@@ -4,7 +4,8 @@
     ProfileSelector,
     TextSize,
     CursorHighlight,
-    LineHeight 
+    LineHeight,
+    ReduceAnimation
   } from '$lib';
   import { fade } from 'svelte/transition';
 
@@ -20,7 +21,7 @@
   <ProfileSelector />
   <TextSize/>
   <LineHeight/>
- 
+  <ReduceAnimation/>
 
   <button popovertarget="a11y-menu" popovertargetaction="hide">x</button>
 </div>

--- a/src/lib/components/a11y_options/cursorHighlight.svelte
+++ b/src/lib/components/a11y_options/cursorHighlight.svelte
@@ -59,31 +59,6 @@
 		updateCursorStyles();
 	}
 
-	// when the mouse is hovering over a link the cursor will lose it's outline and the link will get a red border 
-	// and the cursor will be visible
-	onMount(() => {
-		let links = document.querySelectorAll('a');
-		links.forEach((el) => {
-			el.addEventListener('mouseover', () => {
-				document.body.classList.add('dim');
-				document.body.querySelectorAll('*').forEach(e => e.classList.add('dim'));
-
-				el.classList.remove('dim');
-				el.classList.add('hoverLink');
-				el.style.border = 'solid 2px red';
-				document.documentElement.style.setProperty('--opacity-cursor', '1');
-			});
-			el.addEventListener('mouseout', () => {
-				document.body.classList.remove('dim');
-				el.classList.remove('hoverLink');
-				el.style.border = 'none';
-				document.documentElement.style.setProperty('--opacity-cursor', '0');
-			});
-		});
-
-	});
-
-
 </script>
 
 <button onclick={toggleAfter}>
@@ -91,21 +66,6 @@
 </button>
 
 <style>
-
-	/* Dim all links */
-:global(body.dim *)  {
-	opacity: 0.2;
-	transition: opacity 0.3s ease;
-}
-
-/* Except the one we're hovering on */
-:global(a.hoverLink) {
-	opacity: 1 !important;
-	border: solid 2px red; /* fallback in case JS fails */
-	z-index: 10;
-	position: relative;
-}
-
 
 :global(html:has(.buttonBox button[popovertarget="a11y-menu"]) .buttonBox::after) {
 	content: '';
@@ -119,7 +79,7 @@
 	opacity: var(--opacity-cursor, 1);
 	border-radius: 50%;
 	mix-blend-mode: screen;
-	transition: opacity 0.5s ease-out;
+	transition: opacity 0.5ms ease-out;
 	pointer-events: none;
 	transform-origin: center center;
 	transform: translate(calc(-.5 * var(--sizeX-cursor)), calc(-.5 * var(--sizeX-cursor)) );

--- a/src/lib/components/a11y_options/linkHighlight.svelte
+++ b/src/lib/components/a11y_options/linkHighlight.svelte
@@ -1,0 +1,64 @@
+<script>
+	import { onMount } from 'svelte';
+
+	// when the mouse is hovering over a link the cursor will lose it's outline and the link will get a red border 
+	// and the cursor will be visible
+	//werkt alleen in onMount
+	onMount(() => {
+		let links = document.querySelectorAll('a');
+		// zoek alle links in de body
+		// en voeg een event listener toe aan elk element
+		links.forEach((el) => {
+			let selectedElement = 'h1, h2, h3, h4, h5, h6, p, blockquote, pre,a, abbr, acronym, address, big, cite, code,del, dfn, em, img, ins, kbd, q, s, samp,small, strike, strong, sub, sup, tt, var,b, u, i';
+			el.addEventListener('mouseover', () => {
+				document.body.querySelectorAll(selectedElement).forEach(e => {
+					//geef alles een dim class
+					e.classList.add('dim')
+				});
+				
+				// behalve de geselecteerde link
+				el.classList.remove('dim');
+				el.classList.add('undim')
+
+				// en geef de geselecteerde link een hoverLink class
+				el.classList.add('hoverLink');
+				el.style.border = 'solid 2px red';
+				document.documentElement.style.setProperty('--opacity-cursor', '0');
+
+			});
+			// remove alles wanneer de muis niet meer over de link is
+			el.addEventListener('mouseout', () => {
+				document.body.querySelectorAll('*').forEach(e => {
+					e.classList.remove('dim')
+				});
+				el.classList.remove('hoverLink');
+				el.style.border = 'none';
+				document.documentElement.style.setProperty('--opacity-cursor', '1');
+			});
+		});
+
+	});
+
+</script>
+
+
+
+<style>
+/* Dim everything */
+:global(.dim)  {
+	color: #0003;	
+}
+/* besides the selected link */
+:global(.undim) {
+	color: black;	
+}
+
+/* Except the one we're hovering on */
+:global(a.hoverLink) {
+	opacity: 1 !important;
+	border: solid 2px red; /* fallback in case JS fails */
+	z-index: 10;
+	position: relative;
+}
+
+</style>

--- a/src/lib/components/a11y_options/reduceAnimation.svelte
+++ b/src/lib/components/a11y_options/reduceAnimation.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let enabled = false;
+	const storageKey = 'reduced-motion';
+
+	// Zet of haal de waarde uit localStorage bij laden
+	onMount(() => {
+		const stored = localStorage.getItem(storageKey);
+		if (stored === 'true') {
+			enabled = true;
+		} else if (stored === 'false') {
+			enabled = false;
+		} else {
+			// Gebruik systeemvoorkeur als er niks is opgeslagen
+			enabled = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		}
+		updateBodyClass();
+	});
+
+	// Toggle de waarde en sla op
+	function toggle() {
+		enabled = !enabled;
+		localStorage.setItem(storageKey, String(enabled));
+		updateBodyClass();
+	}
+
+	// Zet de juiste klasse op <body>
+	function updateBodyClass() {
+		if (typeof document !== 'undefined') {
+			document.body.classList.toggle('reduced-motion', enabled);
+		}
+	}
+</script>
+
+<div class="flex items-center justify-between" role="group" aria-labelledby="reduced-motion-label">
+	<div>
+		<label id="reduced-motion-label" for="reduced-motion-control" class="font-medium">
+			Reduced Motion
+		</label>
+		<p id="reduced-motion-description" class="text-sm text-gray-500 font-normal">
+			Minimizes animations and transitions
+		</p>
+	</div>
+
+	<!-- Verborgen checkbox -->
+	<div class="relative inline-block w-12 h-6">
+		<input
+			id="reduced-motion-control"
+			type="checkbox"
+			class="sr-only"
+			checked={enabled}
+			on:change={toggle}
+			aria-describedby="reduced-motion-description"
+			aria-checked={enabled}
+		/>
+
+		<!-- Custom switch -->
+		<span
+			class={`absolute cursor-pointer top-0 left-0 right-0 bottom-0 rounded-full transition-colors duration-200 ${
+				enabled ? 'bg-blue-600' : 'bg-gray-300'
+			}`}
+			on:click={toggle}
+			role="presentation"
+		>
+			<span
+				class={`absolute h-4 w-4 left-1 bottom-1 bg-white rounded-full transition-transform duration-200 ${
+					enabled ? 'transform translate-x-6' : ''
+				}`}
+				aria-hidden="true"
+			></span>
+		</span>
+	</div>
+
+	<div class="sr-only" aria-live="polite">
+		Reduced motion is {enabled ? 'enabled' : 'disabled'}
+	</div>
+</div>
+
+<style>
+    :global(body.reduced-motion) * {
+      animation-duration: 0s !important;
+      transition-duration: 0s !important;
+      animation-iteration-count: 1 !important;
+    }
+
+    label#reduced-motion-label {
+		font-weight: bold;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,24 +37,57 @@
   
  
     
-  <h1>Welcome to your library project Test AccessibilityTool</h1>
-  <p>Create your package using @sveltejs/package and preview/showcase your work with SvelteKit</p>
-  <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+  <h1 class="fade-in">Welcome to your library project Test AccessibilityTool</h1>
+<p class="fade-in delay">Create your package using @sveltejs/package and preview/showcase your work with SvelteKit</p>
+<p class="fade-in delay2">
+  Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation
+</p>
   <AccessibilityMenu ></AccessibilityMenu>
 
   <style>
-    :root{
+    :root {
       --font-size: 1rem;
     }
-
+  
     h1 {
-      font-size: max(3rem,var(--font-size));
-      line-height: var(--line-height,100%);
+      font-size: max(3rem, var(--font-size));
+      line-height: var(--line-height, 100%);
     }
-
+  
     p {
-      font-size: max(1.5rem,var(--font-size));
-      line-height: var(--line-height,100%);
-
+      font-size: max(1.5rem, var(--font-size));
+      line-height: var(--line-height, 100%);
     }
+  
+    /* Animatie keyframes */
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  
+    /* Fade-in class */
+    .fade-in {
+      animation: fadeIn 1s ease forwards;
+    }
+  
+    /* Delays voor mooie stagger */
+    .delay {
+      animation-delay: 0.3s;
+    }
+  
+    .delay2 {
+      animation-delay: 0.6s;
+    }
+  
+    /* body.reduced-motion .fade-in {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+    } */
   </style>


### PR DESCRIPTION
## Wat heb ik gedaan?

Ik heb de toegankelijkheidsopties van de app verbeterd. Er is nu een instelling om animaties uit te zetten (reduced motion), en ik heb de logica voor het highlighten van links opgesplitst in een aparte component. Ook heb ik de code wat opgeschoond.

---

##  Toegevoegde onderdelen

- **Nieuwe component: `ReduceAnimation.svelte`**
  - Gebruiker kan hiermee animaties uitschakelen via een toggle.
  - Slaat voorkeur op in `localStorage`.
  - Als er geen voorkeur is, kijkt de app naar de systeeminstellingen van de gebruiker.
  - Zet een `.reduced-motion` class op `<body>`.

- **CSS aanpassing in `app.css`**
  - Als `.reduced-motion` actief is, worden animaties, overgangen en scroll-effecten uitgeschakeld met `!important`.

- **Nieuwe component: `linkHighlight.svelte`**
  - Afkomstig uit oude `cursorHighlight.svelte`.
  - Dimt alle tekst op de pagina behalve de link waar je met de muis overheen gaat.
  - Geeft actieve links een rode rand en zorgt dat ze visueel opvallen.

---

##  Refactored

- **Oude hover-logica verwijderd uit `cursorHighlight.svelte`**  
  Deze is nu netjes overgezet naar `linkHighlight.svelte`.

- **Startpagina (`+page.svelte`)**
  - Fade-in animaties toegevoegd aan tekst om t testen.
  - Houdt rekening met `reduced-motion`: animaties worden automatisch uitgeschakeld.

---

- **Gebruik van `!important` in CSS**  
  Dit is nodig om bestaande animaties of overgangen echt uit te zetten als een gebruiker dat wil.

- **Slimme selectors in `linkHighlight.svelte`**  
  In plaats van alles op de pagina te dimmen, worden alleen veelgebruikte tekst-elementen gedimd zoals koppen en paragrafen. Zo blijft de structuur van de pagina intact.

- **Systematische opslag van voorkeur**  
  De keuze van de gebruiker wordt opgeslagen met `localStorage`, en als er nog niks gekozen is, wordt gekeken naar de voorkeur van het besturingssysteem (via `matchMedia`).